### PR TITLE
Specify Kotlin JVM target

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
     viewBinding {
         enable true
     }


### PR DESCRIPTION
Specify JVM 17 is the target for Kotlin, to avoid possible issues when default installed JVM is newer (e.g. 21).

Error message:
"Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (21)"